### PR TITLE
Adjust TypeScript preset

### DIFF
--- a/src/oxlint/OxlintPreset.ts
+++ b/src/oxlint/OxlintPreset.ts
@@ -91,7 +91,7 @@ export function oxlintPreset(): OxlintConfig {
 			"eslint/no-extra-bind": "warn",
 			"eslint/no-extra-boolean-cast": "warn",
 			"eslint/no-extra-label": "warn", // Superseded by `eslint/no-labels`.
-			"eslint/no-fallthrough": "warn",
+			// "eslint/no-fallthrough": "off", // Superseded by `noFallthroughCasesInSwitch` in TypeScript.
 			"eslint/no-func-assign": "warn",
 			"eslint/no-global-assign": "warn",
 			"eslint/no-implicit-coercion": "warn",

--- a/src/typescript/index.jsonc
+++ b/src/typescript/index.jsonc
@@ -6,20 +6,15 @@
 		"exactOptionalPropertyTypes": true,
 		"forceConsistentCasingInFileNames": true,
 		"isolatedModules": true,
-		"libReplacement": false,
+		"moduleResolution": "bundler", // Required by `allowImportingTsExtensions`.
 		"noEmit": true,
 		"noEmitOnError": true,
-		"noImplicitAny": true,
 		"noImplicitOverride": true,
 		"noImplicitReturns": true,
-		"noImplicitThis": true,
 		"noUncheckedIndexedAccess": true,
-		"noUncheckedSideEffectImports": true,
 		"resolveJsonModule": true,
 		"skipLibCheck": true,
 		"sourceMap": false,
-		"strict": true,
-		"useDefineForClassFields": true,
 		"verbatimModuleSyntax": true
 	}
 }

--- a/src/typescript/index.jsonc
+++ b/src/typescript/index.jsonc
@@ -2,13 +2,9 @@
 	"$schema": "https://json.schemastore.org/tsconfig",
 	"compilerOptions": {
 		"allowImportingTsExtensions": true,
-		"allowJs": false,
-		"checkJs": false,
 		"erasableSyntaxOnly": true,
-		"esModuleInterop": true,
 		"exactOptionalPropertyTypes": true,
 		"forceConsistentCasingInFileNames": true,
-		"importHelpers": true,
 		"isolatedModules": true,
 		"libReplacement": false,
 		"noEmit": true,

--- a/src/typescript/index.jsonc
+++ b/src/typescript/index.jsonc
@@ -9,6 +9,7 @@
 		"moduleResolution": "bundler", // Required by `allowImportingTsExtensions`.
 		"noEmit": true,
 		"noEmitOnError": true,
+		"noFallthroughCasesInSwitch": true,
 		"noImplicitOverride": true,
 		"noImplicitReturns": true,
 		"noUncheckedIndexedAccess": true,


### PR DESCRIPTION
Relying on the default behaviour simplifies the preset.

`noUncheckedSideEffectImports`, `strict`, and `useDefineForClassFields` are enabled by default in TypeScript 6. Likewise, `libReplacement` is disabled by default.

`strict` automatically enables `noImplicitAny` and `noImplicitThis`.

https://devblogs.microsoft.com/typescript/announcing-typescript-6-0/#simple-default-changes

The TypeScript preset should not provide compatibility for CommonJS or downlevelling.