### PR TITLE
Use caret (^) ranges in peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,8 +51,8 @@
 		"vite": "Vite is a development server and a bundler."
 	},
 	"peerDependencies": {
-		"oxfmt": ">=0.48.0 <1.0.0",
-		"oxlint": ">=1.66.0 <2.0.0",
-		"typescript": ">=6.0.2 <8.0.0"
+		"oxfmt": "^0.48.0",
+		"oxlint": "^1.66.0",
+		"typescript": "^6.0.2"
 	}
 }


### PR DESCRIPTION
This is an attempt to make Renovate pick up peer dependency ranges correctly, following commit 98bd931.