### PR TITLE
Sort object keys in Oxlint presets

### DIFF
--- a/src/oxlint/OxlintNextjsPreset.ts
+++ b/src/oxlint/OxlintNextjsPreset.ts
@@ -7,32 +7,6 @@ import type { OxlintConfig } from "oxlint"
 export function oxlintNextjsPreset(): OxlintConfig {
 	return {
 		ignorePatterns: [".next/**/*", "next-env.d.ts"],
-		plugins: ["nextjs"],
-		rules: {
-			// "nextjs/google-font-display": "off", // Unconfigured.
-			// "nextjs/google-font-preconnect": "off", // Unconfigured.
-			"nextjs/inline-script-id": "warn",
-			// "nextjs/next-script-for-ga": "off", // Unconfigured.
-			"nextjs/no-assign-module-variable": "warn",
-			"nextjs/no-async-client-component": "warn",
-			// "nextjs/no-before-interactive-script-outside-document": "off", // Not applicable in the app router.
-			"nextjs/no-css-tags": "warn",
-			// "nextjs/no-document-import-in-page": "off", // Not applicable in the app router.
-			// "nextjs/no-duplicate-head": "off", // Not applicable in the app router.
-			"nextjs/no-head-element": "warn",
-			// "nextjs/no-head-import-in-document": "off", // Not applicable in the app router.
-			"nextjs/no-html-link-for-pages": "warn",
-			"nextjs/no-img-element": "warn",
-			// "nextjs/no-page-custom-font": "off", // Not applicable in the app router.
-			"nextjs/no-script-component-in-head": "warn",
-			// "nextjs/no-styled-jsx-in-document": "off", // Not applicable in the app router.
-			"nextjs/no-sync-scripts": "warn",
-			"nextjs/no-title-in-document-head": "warn",
-			// "nextjs/no-typos": "off", // Not applicable in the app router.
-			"nextjs/no-unwanted-polyfillio": "warn",
-			"unicorn/no-typeof-undefined": "off", // Next.js does not support `globalThis`.
-			"unicorn/prefer-global-this": "off", // Next.js does not support `globalThis`.
-		},
 		overrides: [
 			{
 				files: ["src/app/**/*"],
@@ -122,5 +96,31 @@ export function oxlintNextjsPreset(): OxlintConfig {
 				},
 			},
 		],
+		plugins: ["nextjs"],
+		rules: {
+			// "nextjs/google-font-display": "off", // Unconfigured.
+			// "nextjs/google-font-preconnect": "off", // Unconfigured.
+			"nextjs/inline-script-id": "warn",
+			// "nextjs/next-script-for-ga": "off", // Unconfigured.
+			"nextjs/no-assign-module-variable": "warn",
+			"nextjs/no-async-client-component": "warn",
+			// "nextjs/no-before-interactive-script-outside-document": "off", // Not applicable in the app router.
+			"nextjs/no-css-tags": "warn",
+			// "nextjs/no-document-import-in-page": "off", // Not applicable in the app router.
+			// "nextjs/no-duplicate-head": "off", // Not applicable in the app router.
+			"nextjs/no-head-element": "warn",
+			// "nextjs/no-head-import-in-document": "off", // Not applicable in the app router.
+			"nextjs/no-html-link-for-pages": "warn",
+			"nextjs/no-img-element": "warn",
+			// "nextjs/no-page-custom-font": "off", // Not applicable in the app router.
+			"nextjs/no-script-component-in-head": "warn",
+			// "nextjs/no-styled-jsx-in-document": "off", // Not applicable in the app router.
+			"nextjs/no-sync-scripts": "warn",
+			"nextjs/no-title-in-document-head": "warn",
+			// "nextjs/no-typos": "off", // Not applicable in the app router.
+			"nextjs/no-unwanted-polyfillio": "warn",
+			"unicorn/no-typeof-undefined": "off", // Next.js does not support `globalThis`.
+			"unicorn/prefer-global-this": "off", // Next.js does not support `globalThis`.
+		},
 	}
 }

--- a/src/oxlint/OxlintNextjsPreset.ts
+++ b/src/oxlint/OxlintNextjsPreset.ts
@@ -1,4 +1,4 @@
-import type { OxlintConfig } from "oxlint"
+import type { OxlintConfig, OxlintOverride } from "oxlint"
 
 /**
  * @see https://oxc.rs/docs/guide/usage/linter/config-file-reference.html
@@ -7,95 +7,7 @@ import type { OxlintConfig } from "oxlint"
 export function oxlintNextjsPreset(): OxlintConfig {
 	return {
 		ignorePatterns: [".next/**/*", "next-env.d.ts"],
-		overrides: [
-			{
-				files: ["src/app/**/*"],
-				rules: {
-					"eslint/max-lines": ["warn", { max: 0 }], // Disallow non-route files in the `app` directory.
-				},
-			},
-			{
-				// App router.
-				// https://nextjs.org/docs/app/api-reference/file-conventions
-				// https://nextjs.org/docs/app/api-reference/functions
-				files: [
-					"src/app/**/apple-icon.{ts,tsx}",
-					"src/app/**/default.{ts,tsx}",
-					"src/app/**/error.{ts,tsx}",
-					"src/app/**/forbidden.{ts,tsx}",
-					"src/app/**/global-error.{ts,tsx}",
-					"src/app/**/icon.{ts,tsx}",
-					"src/app/**/layout.{ts,tsx}",
-					"src/app/**/loading.{ts,tsx}",
-					"src/app/**/not-found.{ts,tsx}",
-					"src/app/**/opengraph-image.{ts,tsx}",
-					"src/app/**/page.{ts,tsx}",
-					"src/app/**/route.ts",
-					"src/app/**/sitemap.ts",
-					"src/app/**/template.{ts,tsx}",
-					"src/app/**/twitter-image.{ts,tsx}",
-					"src/app/**/unauthorized.{ts,tsx}",
-					"src/app/manifest.ts",
-					"src/app/robots.ts",
-					"src/instrumentation-*.ts",
-					"src/instrumentation.ts",
-					"src/mdx-components.{ts,tsx}",
-					"src/middleware.ts", // Next.js 15.
-					"src/proxy.ts", // Next.js 16 and newer.
-				],
-				rules: {
-					"eslint/max-lines": "off", // Allow route files in the `app` directory.
-					"eslint/no-restricted-exports": "off", // Allow default exports of pages and layouts.
-					"react/jsx-filename-extension": "off",
-					"react/only-export-components": [
-						"warn",
-						{
-							allowExportNames: [
-								"generateImageMetadata",
-								"generateMetadata",
-								"generateStaticParams",
-								"generateViewport",
-								"metadata",
-								"runtime",
-								"viewport",
-							],
-						},
-					],
-					"unicorn/filename-case": "off", // Allow all route names.
-				},
-			},
-			{
-				// Layouts.
-				files: ["src/app/**/layout.tsx"],
-				rules: {
-					"eslint/no-restricted-imports": [
-						"warn",
-						{
-							paths: [
-								{
-									name: "react",
-									importNames: ["Suspense"],
-									message:
-										"Layout components must not use `<Suspense>`, as it interferes with some routing optimisations done by Next.js.",
-								},
-							],
-						},
-					],
-					// "typescript/no-restricted-types": [
-					// 	"warn",
-					// 	{
-					// 		types: {
-					// 			Suspendable: {
-					// 				message:
-					// 					"Layout components must not be async, as it interferes with some routing optimisations done by Next.js. Use `Renderable` instead of `Suspendable`.",
-					// 				use: "Renderable",
-					// 			},
-					// 		},
-					// 	},
-					// ],
-				},
-			},
-		],
+		overrides: [overrideNonRoutes(), overrideRoutes(), overrideLayouts()],
 		plugins: ["nextjs"],
 		rules: {
 			// "nextjs/google-font-display": "off", // Unconfigured.
@@ -121,6 +33,103 @@ export function oxlintNextjsPreset(): OxlintConfig {
 			"nextjs/no-unwanted-polyfillio": "warn",
 			"unicorn/no-typeof-undefined": "off", // Next.js does not support `globalThis`.
 			"unicorn/prefer-global-this": "off", // Next.js does not support `globalThis`.
+		},
+	}
+}
+
+function overrideNonRoutes(): OxlintOverride {
+	return {
+		files: ["src/app/**/*"],
+		rules: {
+			"eslint/max-lines": ["warn", { max: 0 }], // Disallow non-route files in the `app` directory.
+		},
+	}
+}
+
+/**
+ * @see https://nextjs.org/docs/app/api-reference/file-conventions
+ * @see https://nextjs.org/docs/app/api-reference/functions
+ */
+function overrideRoutes(): OxlintOverride {
+	return {
+		files: [
+			"src/app/**/apple-icon.{ts,tsx}",
+			"src/app/**/default.{ts,tsx}",
+			"src/app/**/error.{ts,tsx}",
+			"src/app/**/forbidden.{ts,tsx}",
+			"src/app/**/global-error.{ts,tsx}",
+			"src/app/**/icon.{ts,tsx}",
+			"src/app/**/layout.{ts,tsx}",
+			"src/app/**/loading.{ts,tsx}",
+			"src/app/**/not-found.{ts,tsx}",
+			"src/app/**/opengraph-image.{ts,tsx}",
+			"src/app/**/page.{ts,tsx}",
+			"src/app/**/route.ts",
+			"src/app/**/sitemap.ts",
+			"src/app/**/template.{ts,tsx}",
+			"src/app/**/twitter-image.{ts,tsx}",
+			"src/app/**/unauthorized.{ts,tsx}",
+			"src/app/manifest.ts",
+			"src/app/robots.ts",
+			"src/instrumentation-*.ts",
+			"src/instrumentation.ts",
+			"src/mdx-components.{ts,tsx}",
+			"src/middleware.ts", // Next.js 15.
+			"src/proxy.ts", // Next.js 16 and newer.
+		],
+		rules: {
+			"eslint/max-lines": "off", // Allow route files in the `app` directory.
+			"eslint/no-restricted-exports": "off", // Allow default exports of pages and layouts.
+			"react/jsx-filename-extension": "off",
+			"react/only-export-components": [
+				"warn",
+				{
+					allowExportNames: [
+						"generateImageMetadata",
+						"generateMetadata",
+						"generateStaticParams",
+						"generateViewport",
+						"metadata",
+						"runtime",
+						"viewport",
+					],
+				},
+			],
+			"unicorn/filename-case": "off", // Allow all route names.
+		},
+	}
+}
+
+function overrideLayouts(): OxlintOverride {
+	return {
+		// Layouts.
+		files: ["src/app/**/layout.tsx"],
+		rules: {
+			"eslint/no-restricted-imports": [
+				"warn",
+				{
+					paths: [
+						{
+							name: "react",
+							importNames: ["Suspense"],
+							message:
+								"Layout components must not use `<Suspense>`, as it interferes with some routing optimisations done by Next.js.",
+						},
+					],
+				},
+			],
+			// "typescript/no-restricted-types": [
+			// 	"warn",
+			// 	{
+			// 		types: {
+			// 			Suspendable: {
+			// 				message:
+			// 					"Layout components must not be async, as it interferes with some routing optimisations done by Next.js. Use `Renderable` instead of `Suspendable`.",
+			// 				use: "Renderable",
+			// 			},
+			// 		},
+			// 	},
+			// ],
 		},
 	}
 }

--- a/src/oxlint/OxlintPreset.ts
+++ b/src/oxlint/OxlintPreset.ts
@@ -1,4 +1,4 @@
-import type { OxlintConfig } from "oxlint"
+import type { OxlintConfig, OxlintOverride } from "oxlint"
 import { oxlintRestrictedImportPatterns } from "#oxlint/OxlintRestrictedImportPattern.ts"
 
 /**
@@ -21,129 +21,14 @@ export function oxlintPreset(): OxlintConfig {
 		},
 		ignorePatterns: [".idea/**/*", "node_modules/**/*"],
 		overrides: [
-			{
-				// Test fixtures.
-				files: ["src/**/*.fixtures.{ts,tsx}"],
-				rules: {
-					"eslint/complexity": ["warn", { max: 12, variant: "modified" }],
-					"eslint/no-restricted-imports": [
-						"warn",
-						{
-							patterns: oxlintRestrictedImportPatterns({
-								allowFixtures: true,
-							}),
-						},
-					],
-				},
-			},
-			{
-				// Module mocks.
-				files: ["src/**/*.mocks.{ts,tsx}"],
-				rules: {
-					"eslint/complexity": ["warn", { max: 12, variant: "modified" }],
-					"eslint/no-restricted-imports": [
-						"warn",
-						{
-							patterns: oxlintRestrictedImportPatterns({
-								allowFixtures: true,
-								allowMocks: true,
-							}),
-						},
-					],
-				},
-			},
-			{
-				// Unit tests.
-				files: ["src/**/*.tests.{ts,tsx}"],
-				rules: {
-					"eslint/complexity": ["warn", { max: 4, variant: "modified" }],
-					"eslint/no-restricted-imports": [
-						"warn",
-						{
-							patterns: oxlintRestrictedImportPatterns({
-								allowMocks: true,
-								allowFixtures: true,
-							}),
-						},
-					],
-					"vitest/consistent-test-it": ["warn", { fn: "it", withinDescribe: "it" }],
-					"vitest/expect-expect": "warn",
-					"vitest/no-commented-out-tests": "warn",
-					"vitest/no-conditional-expect": "warn",
-					"vitest/no-conditional-in-test": "warn",
-					"vitest/no-conditional-tests": "warn",
-					"vitest/no-duplicate-hooks": "warn",
-					"vitest/no-standalone-expect": "warn",
-					"vitest/no-test-return-statement": "warn",
-					"vitest/no-unneeded-async-expect-function": "warn",
-					"vitest/prefer-describe-function-title": "warn",
-					"vitest/prefer-each": "warn",
-					"vitest/prefer-hooks-in-order": "warn",
-					"vitest/prefer-hooks-on-top": "warn",
-					"vitest/prefer-lowercase-title": "warn",
-					"vitest/require-hook": "warn",
-					"vitest/valid-describe-callback": "warn",
-					"vitest/valid-expect": "warn",
-					"vitest/valid-title": "warn",
-				},
-			},
-			{
-				// Ambient TypeScript modules (i.e. type declaration files).
-				files: ["src/**/*.d.ts"],
-				rules: {
-					"typescript/consistent-type-definitions": "off", // Allow interfaces for type declaration merging.
-				},
-			},
-			{
-				// Configuration files.
-				files: ["./*.config.{js,ts}"],
-				rules: {
-					"eslint/no-restricted-exports": "off", // Allow default exports.
-					"eslint/no-restricted-imports": [
-						"warn",
-						{
-							patterns: oxlintRestrictedImportPatterns({
-								allowRelativePaths: true,
-								allowNodejs: true,
-							}),
-						},
-					],
-					"unicorn/filename-case": ["warn", { case: "kebabCase" }],
-				},
-			},
-			{
-				// Scripts.
-				files: ["**/*.script.{js,ts}"],
-				rules: {
-					"eslint/no-console": "off",
-					"eslint/no-restricted-imports": [
-						"warn",
-						{
-							patterns: oxlintRestrictedImportPatterns({
-								allowRelativePaths: true,
-								allowNodejs: true,
-							}),
-						},
-					],
-					"unicorn/filename-case": ["warn", { case: "kebabCase" }],
-					"unicorn/no-process-exit": "off",
-				},
-			},
-			{
-				// Custom `Error` subclasses.
-				files: ["src/**/*Error.ts"],
-				rules: {
-					"eslint/max-classes-per-file": "warn",
-				},
-			},
-			{
-				// Program entrypoints.
-				files: ["src/main-*.ts"],
-				rules: {
-					"unicorn/filename-case": ["warn", { case: "kebabCase" }],
-					"unicorn/no-process-exit": "off",
-				},
-			},
+			overrideFixtures(),
+			overrideMocks(),
+			overrideTests(),
+			overrideAmbientTypescriptModules(),
+			overrideConfigs(),
+			overrideScripts(),
+			overrideCustomErrorSubclasses(),
+			overrideProgramEntrypoints(),
 		],
 		plugins: ["typescript", "unicorn", "vitest"],
 		rules: {
@@ -696,6 +581,148 @@ export function oxlintPreset(): OxlintConfig {
 			"vitest/valid-expect-in-promise": "warn",
 			// "vitest/valid-title": "off",
 			// "vitest/warn-todo": "off", // Allow unit tests to be disabled.
+		},
+	}
+}
+
+function overrideFixtures(): OxlintOverride {
+	return {
+		files: ["src/**/*.fixtures.{ts,tsx}"],
+		rules: {
+			"eslint/complexity": ["warn", { max: 12, variant: "modified" }],
+			"eslint/no-restricted-imports": [
+				"warn",
+				{
+					patterns: oxlintRestrictedImportPatterns({
+						allowFixtures: true,
+					}),
+				},
+			],
+		},
+	}
+}
+
+function overrideMocks(): OxlintOverride {
+	return {
+		files: ["src/**/*.mocks.{ts,tsx}"],
+		rules: {
+			"eslint/complexity": ["warn", { max: 12, variant: "modified" }],
+			"eslint/no-restricted-imports": [
+				"warn",
+				{
+					patterns: oxlintRestrictedImportPatterns({
+						allowFixtures: true,
+						allowMocks: true,
+					}),
+				},
+			],
+		},
+	}
+}
+
+function overrideTests(): OxlintOverride {
+	return {
+		files: ["src/**/*.tests.{ts,tsx}"],
+		rules: {
+			"eslint/complexity": ["warn", { max: 4, variant: "modified" }],
+			"eslint/no-restricted-imports": [
+				"warn",
+				{
+					patterns: oxlintRestrictedImportPatterns({
+						allowMocks: true,
+						allowFixtures: true,
+					}),
+				},
+			],
+			"vitest/consistent-test-it": ["warn", { fn: "it", withinDescribe: "it" }],
+			"vitest/expect-expect": "warn",
+			"vitest/no-commented-out-tests": "warn",
+			"vitest/no-conditional-expect": "warn",
+			"vitest/no-conditional-in-test": "warn",
+			"vitest/no-conditional-tests": "warn",
+			"vitest/no-duplicate-hooks": "warn",
+			"vitest/no-standalone-expect": "warn",
+			"vitest/no-test-return-statement": "warn",
+			"vitest/no-unneeded-async-expect-function": "warn",
+			"vitest/prefer-describe-function-title": "warn",
+			"vitest/prefer-each": "warn",
+			"vitest/prefer-hooks-in-order": "warn",
+			"vitest/prefer-hooks-on-top": "warn",
+			"vitest/prefer-lowercase-title": "warn",
+			"vitest/require-hook": "warn",
+			"vitest/valid-describe-callback": "warn",
+			"vitest/valid-expect": "warn",
+			"vitest/valid-title": "warn",
+		},
+	}
+}
+
+/**
+ * Also known as 'type declaration files'.
+ */
+function overrideAmbientTypescriptModules(): OxlintOverride {
+	return {
+		files: ["src/**/*.d.ts"],
+		rules: {
+			"typescript/consistent-type-definitions": "off", // Allow interfaces for type declaration merging.
+		},
+	}
+}
+
+function overrideConfigs(): OxlintOverride {
+	return {
+		files: ["./*.config.{js,ts}"],
+		rules: {
+			"eslint/no-restricted-exports": "off", // Allow default exports.
+			"eslint/no-restricted-imports": [
+				"warn",
+				{
+					patterns: oxlintRestrictedImportPatterns({
+						allowRelativePaths: true,
+						allowNodejs: true,
+					}),
+				},
+			],
+			"unicorn/filename-case": ["warn", { case: "kebabCase" }],
+		},
+	}
+}
+
+function overrideScripts(): OxlintOverride {
+	return {
+		files: ["**/*.script.{js,ts}"],
+		rules: {
+			"eslint/no-console": "off",
+			"eslint/no-restricted-imports": [
+				"warn",
+				{
+					patterns: oxlintRestrictedImportPatterns({
+						allowRelativePaths: true,
+						allowNodejs: true,
+					}),
+				},
+			],
+			"unicorn/filename-case": ["warn", { case: "kebabCase" }],
+			"unicorn/no-process-exit": "off",
+		},
+	}
+}
+
+function overrideCustomErrorSubclasses(): OxlintOverride {
+	return {
+		files: ["src/**/*Error.ts"],
+		rules: {
+			"eslint/max-classes-per-file": "warn",
+		},
+	}
+}
+
+function overrideProgramEntrypoints(): OxlintOverride {
+	return {
+		files: ["src/main-*.ts"],
+		rules: {
+			"unicorn/filename-case": ["warn", { case: "kebabCase" }],
+			"unicorn/no-process-exit": "off",
 		},
 	}
 }

--- a/src/oxlint/OxlintPreset.ts
+++ b/src/oxlint/OxlintPreset.ts
@@ -7,7 +7,6 @@ import { oxlintRestrictedImportPatterns } from "#oxlint/OxlintRestrictedImportPa
  */
 export function oxlintPreset(): OxlintConfig {
 	return {
-		ignorePatterns: [".idea/**/*", "node_modules/**/*"],
 		/**
 		 * Disable all rules by default, then opt in to specific rules one by one.
 		 */
@@ -20,6 +19,132 @@ export function oxlintPreset(): OxlintConfig {
 			style: "off",
 			suspicious: "off",
 		},
+		ignorePatterns: [".idea/**/*", "node_modules/**/*"],
+		overrides: [
+			{
+				// Test fixtures.
+				files: ["src/**/*.fixtures.{ts,tsx}"],
+				rules: {
+					"eslint/complexity": ["warn", { max: 12, variant: "modified" }],
+					"eslint/no-restricted-imports": [
+						"warn",
+						{
+							patterns: oxlintRestrictedImportPatterns({
+								allowFixtures: true,
+							}),
+						},
+					],
+				},
+			},
+			{
+				// Module mocks.
+				files: ["src/**/*.mocks.{ts,tsx}"],
+				rules: {
+					"eslint/complexity": ["warn", { max: 12, variant: "modified" }],
+					"eslint/no-restricted-imports": [
+						"warn",
+						{
+							patterns: oxlintRestrictedImportPatterns({
+								allowFixtures: true,
+								allowMocks: true,
+							}),
+						},
+					],
+				},
+			},
+			{
+				// Unit tests.
+				files: ["src/**/*.tests.{ts,tsx}"],
+				rules: {
+					"eslint/complexity": ["warn", { max: 4, variant: "modified" }],
+					"eslint/no-restricted-imports": [
+						"warn",
+						{
+							patterns: oxlintRestrictedImportPatterns({
+								allowMocks: true,
+								allowFixtures: true,
+							}),
+						},
+					],
+					"vitest/consistent-test-it": ["warn", { fn: "it", withinDescribe: "it" }],
+					"vitest/expect-expect": "warn",
+					"vitest/no-commented-out-tests": "warn",
+					"vitest/no-conditional-expect": "warn",
+					"vitest/no-conditional-in-test": "warn",
+					"vitest/no-conditional-tests": "warn",
+					"vitest/no-duplicate-hooks": "warn",
+					"vitest/no-standalone-expect": "warn",
+					"vitest/no-test-return-statement": "warn",
+					"vitest/no-unneeded-async-expect-function": "warn",
+					"vitest/prefer-describe-function-title": "warn",
+					"vitest/prefer-each": "warn",
+					"vitest/prefer-hooks-in-order": "warn",
+					"vitest/prefer-hooks-on-top": "warn",
+					"vitest/prefer-lowercase-title": "warn",
+					"vitest/require-hook": "warn",
+					"vitest/valid-describe-callback": "warn",
+					"vitest/valid-expect": "warn",
+					"vitest/valid-title": "warn",
+				},
+			},
+			{
+				// Ambient TypeScript modules (i.e. type declaration files).
+				files: ["src/**/*.d.ts"],
+				rules: {
+					"typescript/consistent-type-definitions": "off", // Allow interfaces for type declaration merging.
+				},
+			},
+			{
+				// Configuration files.
+				files: ["./*.config.{js,ts}"],
+				rules: {
+					"eslint/no-restricted-exports": "off", // Allow default exports.
+					"eslint/no-restricted-imports": [
+						"warn",
+						{
+							patterns: oxlintRestrictedImportPatterns({
+								allowRelativePaths: true,
+								allowNodejs: true,
+							}),
+						},
+					],
+					"unicorn/filename-case": ["warn", { case: "kebabCase" }],
+				},
+			},
+			{
+				// Scripts.
+				files: ["**/*.script.{js,ts}"],
+				rules: {
+					"eslint/no-console": "off",
+					"eslint/no-restricted-imports": [
+						"warn",
+						{
+							patterns: oxlintRestrictedImportPatterns({
+								allowRelativePaths: true,
+								allowNodejs: true,
+							}),
+						},
+					],
+					"unicorn/filename-case": ["warn", { case: "kebabCase" }],
+					"unicorn/no-process-exit": "off",
+				},
+			},
+			{
+				// Custom `Error` subclasses.
+				files: ["src/**/*Error.ts"],
+				rules: {
+					"eslint/max-classes-per-file": "warn",
+				},
+			},
+			{
+				// Program entrypoints.
+				files: ["src/main-*.ts"],
+				rules: {
+					"unicorn/filename-case": ["warn", { case: "kebabCase" }],
+					"unicorn/no-process-exit": "off",
+				},
+			},
+		],
 		plugins: ["typescript", "unicorn", "vitest"],
 		rules: {
 			"eslint/accessor-pairs": "warn",
@@ -572,130 +697,5 @@ export function oxlintPreset(): OxlintConfig {
 			// "vitest/valid-title": "off",
 			// "vitest/warn-todo": "off", // Allow unit tests to be disabled.
 		},
-		overrides: [
-			{
-				// Test fixtures.
-				files: ["src/**/*.fixtures.{ts,tsx}"],
-				rules: {
-					"eslint/complexity": ["warn", { max: 12, variant: "modified" }],
-					"eslint/no-restricted-imports": [
-						"warn",
-						{
-							patterns: oxlintRestrictedImportPatterns({
-								allowFixtures: true,
-							}),
-						},
-					],
-				},
-			},
-			{
-				// Module mocks.
-				files: ["src/**/*.mocks.{ts,tsx}"],
-				rules: {
-					"eslint/complexity": ["warn", { max: 12, variant: "modified" }],
-					"eslint/no-restricted-imports": [
-						"warn",
-						{
-							patterns: oxlintRestrictedImportPatterns({
-								allowFixtures: true,
-								allowMocks: true,
-							}),
-						},
-					],
-				},
-			},
-			{
-				// Unit tests.
-				files: ["src/**/*.tests.{ts,tsx}"],
-				rules: {
-					"eslint/complexity": ["warn", { max: 4, variant: "modified" }],
-					"eslint/no-restricted-imports": [
-						"warn",
-						{
-							patterns: oxlintRestrictedImportPatterns({
-								allowMocks: true,
-								allowFixtures: true,
-							}),
-						},
-					],
-					"vitest/consistent-test-it": ["warn", { fn: "it", withinDescribe: "it" }],
-					"vitest/expect-expect": "warn",
-					"vitest/no-commented-out-tests": "warn",
-					"vitest/no-conditional-expect": "warn",
-					"vitest/no-conditional-in-test": "warn",
-					"vitest/no-conditional-tests": "warn",
-					"vitest/no-duplicate-hooks": "warn",
-					"vitest/no-standalone-expect": "warn",
-					"vitest/no-test-return-statement": "warn",
-					"vitest/no-unneeded-async-expect-function": "warn",
-					"vitest/prefer-describe-function-title": "warn",
-					"vitest/prefer-each": "warn",
-					"vitest/prefer-hooks-in-order": "warn",
-					"vitest/prefer-hooks-on-top": "warn",
-					"vitest/prefer-lowercase-title": "warn",
-					"vitest/require-hook": "warn",
-					"vitest/valid-describe-callback": "warn",
-					"vitest/valid-expect": "warn",
-					"vitest/valid-title": "warn",
-				},
-			},
-			{
-				// Ambient TypeScript modules (i.e. type declaration files).
-				files: ["src/**/*.d.ts"],
-				rules: {
-					"typescript/consistent-type-definitions": "off", // Allow interfaces for type declaration merging.
-				},
-			},
-			{
-				// Configuration files.
-				files: ["./*.config.{js,ts}"],
-				rules: {
-					"eslint/no-restricted-exports": "off", // Allow default exports.
-					"eslint/no-restricted-imports": [
-						"warn",
-						{
-							patterns: oxlintRestrictedImportPatterns({
-								allowRelativePaths: true,
-								allowNodejs: true,
-							}),
-						},
-					],
-					"unicorn/filename-case": ["warn", { case: "kebabCase" }],
-				},
-			},
-			{
-				// Scripts.
-				files: ["**/*.script.{js,ts}"],
-				rules: {
-					"eslint/no-console": "off",
-					"eslint/no-restricted-imports": [
-						"warn",
-						{
-							patterns: oxlintRestrictedImportPatterns({
-								allowRelativePaths: true,
-								allowNodejs: true,
-							}),
-						},
-					],
-					"unicorn/filename-case": ["warn", { case: "kebabCase" }],
-					"unicorn/no-process-exit": "off",
-				},
-			},
-			{
-				// Custom `Error` subclasses.
-				files: ["src/**/*Error.ts"],
-				rules: {
-					"eslint/max-classes-per-file": "warn",
-				},
-			},
-			{
-				// Program entrypoints.
-				files: ["src/main-*.ts"],
-				rules: {
-					"unicorn/filename-case": ["warn", { case: "kebabCase" }],
-					"unicorn/no-process-exit": "off",
-				},
-			},
-		],
 	}
 }

--- a/src/oxlint/OxlintReactRouterPreset.ts
+++ b/src/oxlint/OxlintReactRouterPreset.ts
@@ -1,4 +1,4 @@
-import type { OxlintConfig } from "oxlint"
+import type { OxlintConfig, OxlintOverride } from "oxlint"
 
 /**
  * @see https://oxc.rs/docs/guide/usage/linter/config-file-reference.html
@@ -6,46 +6,53 @@ import type { OxlintConfig } from "oxlint"
  */
 export function oxlintReactRouterPreset(): OxlintConfig {
 	return {
-		overrides: [
-			{
-				// React Router file routes.
-				// https://reactrouter.com/how-to/file-route-conventions
-				// https://reactrouter.com/start/framework/route-module
-				files: ["src/routes/**.tsx", "src/root.tsx"],
-				rules: {
-					"eslint/no-restricted-exports": "off", // Allow default exports of routes.
-					"react/only-export-components": [
-						"warn",
-						{
-							allowExportNames: [
-								"action",
-								"clientAction",
-								"clientLoader",
-								"clientMiddleware",
-								"ErrorBoundary",
-								"handle",
-								"headers",
-								"HydrateFallback",
-								"links",
-								"loader",
-								// "meta", // Discouraged in React 19.
-								"middleware",
-								"shouldRevalidate",
-							],
-						},
+		overrides: [overrideRoutes(), overrideRouteConfig()],
+	}
+}
+
+/**
+ * @see https://reactrouter.com/how-to/file-route-conventions
+ * @see https://reactrouter.com/start/framework/route-module
+ */
+function overrideRoutes(): OxlintOverride {
+	return {
+		files: ["src/routes/**.tsx", "src/root.tsx"],
+		rules: {
+			"eslint/no-restricted-exports": "off", // Allow default exports of routes.
+			"react/only-export-components": [
+				"warn",
+				{
+					allowExportNames: [
+						"action",
+						"clientAction",
+						"clientLoader",
+						"clientMiddleware",
+						"ErrorBoundary",
+						"handle",
+						"headers",
+						"HydrateFallback",
+						"links",
+						"loader",
+						// "meta", // Discouraged in React 19.
+						"middleware",
+						"shouldRevalidate",
 					],
-					"unicorn/filename-case": "off", // Allow all route names.
 				},
-			},
-			{
-				// Route configuration.
-				// https://reactrouter.com/how-to/file-route-conventions
-				files: ["src/routes.ts"],
-				rules: {
-					"eslint/no-restricted-exports": "off", // Allow default exports of the route configuration.
-					"unicorn/filename-case": "off",
-				},
-			},
-		],
+			],
+			"unicorn/filename-case": "off", // Allow all route names.
+		},
+	}
+}
+
+/**
+ * @see https://reactrouter.com/how-to/file-route-conventions
+ */
+function overrideRouteConfig(): OxlintOverride {
+	return {
+		files: ["src/routes.ts"],
+		rules: {
+			"eslint/no-restricted-exports": "off", // Allow default exports of the route configuration.
+			"unicorn/filename-case": "off",
+		},
 	}
 }

--- a/src/oxlint/OxlintRestrictedImportPattern.ts
+++ b/src/oxlint/OxlintRestrictedImportPattern.ts
@@ -1,107 +1,3 @@
-type OxlintRestrictedImportPattern = {
-	regex: string
-	message: string
-}
-
-type RestrictedImportPatterns = Array<OxlintRestrictedImportPattern>
-
-/**
- * Normalised paths reduce variations in import statements to improve discoverability and reduce diff churn.
- * Using `#` as the path alias prefix preserves compatibility with Node.js subpath imports.
- */
-const normalisedPaths: RestrictedImportPatterns = [
-	{
-		// language=regexp
-		regex: String.raw`[^:]//`, // Allow importing from protocols like `https://`.
-		message: "Delete redundant slash characters.",
-	},
-	{
-		// language=regexp
-		regex: String.raw`/\.\.?/`,
-		message: "Delete path traversal segments like `/./` and `/../`.",
-	},
-	{
-		// language=regexp
-		regex: String.raw`^[#@]/`,
-		message:
-			"Prefer named path aliases (e.g. '#lib/*' and '#utilities/*') over a global wildcard path alias like `#/*` and `@/*`.",
-	},
-	{
-		// language=regexp
-		regex: String.raw`^[^#@\w].+/`, // Allow importing scoped npm packages (`@scope/package-name`).
-		message: "Prefer '#' as the prefix of path aliases.",
-	},
-]
-
-/**
- * Explicit file extensions improve file resolution performance, as tools do not have to guess the correct file extension.
- */
-const explicitFileExtensions: OxlintRestrictedImportPattern = {
-	// language=regexp
-	regex: String.raw`^[#.].*/([^./]+)(\.(decorators|fixtures|mocks|stories|tests))?$`, // Enforce file extensions on local files only.
-	message: "Include the file extension.",
-}
-
-/**
- * Path aliases decouple the code from the directory structure.
- */
-const noRelativePaths: OxlintRestrictedImportPattern = {
-	// language=regexp
-	regex: String.raw`^[/.]`,
-	message: "Prefer path aliases over relative paths.",
-}
-
-/**
- * Using standardised APIs decouples the code from Node.js.
- */
-const noNodeProtocol: OxlintRestrictedImportPattern = {
-	// language=regexp
-	regex: String.raw`^node:.+`,
-	message: "Prefer the standard JavaScript library over Node.js specific modules.",
-}
-
-const noConfigs: OxlintRestrictedImportPattern = {
-	// language=regexp
-	regex: String.raw`\.config\.[jt]s$`,
-	message: "Do not import configuration files.",
-}
-
-const noDecorators: OxlintRestrictedImportPattern = {
-	// language=regexp
-	regex: String.raw`\.decorators\.[jt]sr?x?$`,
-	message: "Do not import story decorators.",
-}
-
-const noFixtures: OxlintRestrictedImportPattern = {
-	// language=regexp
-	regex: String.raw`\.fixtures\.[jt]sr?x?$`,
-	message: "Do not import test fixtures.",
-}
-
-const noMocks: OxlintRestrictedImportPattern = {
-	// language=regexp
-	regex: String.raw`\.mocks\.[jt]sr?x?$`,
-	message: "Do not import module mocks.",
-}
-
-const noScripts: OxlintRestrictedImportPattern = {
-	// language=regexp
-	regex: String.raw`\.script\.[jt]s$`,
-	message: "Do not import Node.js scripts.",
-}
-
-const noStories: OxlintRestrictedImportPattern = {
-	// language=regexp
-	regex: String.raw`\.stories\.[jt]sr?x?$`,
-	message: "Do not import stories.",
-}
-
-const noTests: OxlintRestrictedImportPattern = {
-	// language=regexp
-	regex: String.raw`\.tests\.[jt]sr?x?$`,
-	message: "Do not import unit tests.",
-}
-
 export function oxlintRestrictedImportPatterns(
 	options: {
 		allowRelativePaths?: boolean
@@ -112,18 +8,142 @@ export function oxlintRestrictedImportPatterns(
 		allowStories?: boolean
 		allowTests?: boolean
 	} = {},
-): RestrictedImportPatterns {
+): Array<OxlintRestrictedImportPattern> {
 	return [
-		...normalisedPaths,
-		explicitFileExtensions,
-		options.allowRelativePaths !== true && noRelativePaths,
-		options.allowNodejs !== true && noNodeProtocol,
-		noConfigs,
-		options.allowDecorators !== true && noDecorators,
-		options.allowFixtures !== true && noFixtures,
-		options.allowMocks !== true && noMocks,
-		noScripts,
-		options.allowStories !== true && noStories,
-		options.allowTests !== true && noTests,
+		...normalisedPaths(),
+		explicitFileExtensions(),
+		options.allowRelativePaths !== true && noRelativePaths(),
+		options.allowNodejs !== true && noNodeProtocol(),
+		noConfigs(),
+		options.allowDecorators !== true && noDecorators(),
+		options.allowFixtures !== true && noFixtures(),
+		options.allowMocks !== true && noMocks(),
+		noScripts(),
+		options.allowStories !== true && noStories(),
+		options.allowTests !== true && noTests(),
 	].filter((pattern) => pattern !== false)
+}
+
+type OxlintRestrictedImportPattern = {
+	regex: string
+	message: string
+}
+
+/**
+ * Normalised paths reduce variations in import statements to improve discoverability and reduce diff churn.
+ * Using `#` as the path alias prefix preserves compatibility with Node.js subpath imports.
+ */
+function normalisedPaths(): Array<OxlintRestrictedImportPattern> {
+	return [
+		{
+			// language=regexp
+			regex: String.raw`[^:]//`, // Allow importing from protocols like `https://`.
+			message: "Delete redundant slash characters.",
+		},
+		{
+			// language=regexp
+			regex: String.raw`/\.\.?/`,
+			message: "Delete path traversal segments like `/./` and `/../`.",
+		},
+		{
+			// language=regexp
+			regex: String.raw`^[#@]/`,
+			message:
+				"Prefer named path aliases (e.g. '#lib/*' and '#utilities/*') over a global wildcard path alias like `#/*` and `@/*`.",
+		},
+		{
+			// language=regexp
+			regex: String.raw`^[^#@\w].+/`, // Allow importing scoped npm packages (`@scope/package-name`).
+			message: "Prefer '#' as the prefix of path aliases.",
+		},
+	]
+}
+
+/**
+ * Explicit file extensions improve file resolution performance, as tools do not have to guess the correct file extension.
+ */
+function explicitFileExtensions(): OxlintRestrictedImportPattern {
+	return {
+		// language=regexp
+		regex: String.raw`^[#.].*/([^./]+)(\.(decorators|fixtures|mocks|stories|tests))?$`, // Enforce file extensions on local files only.
+		message: "Include the file extension.",
+	}
+}
+
+/**
+ * Path aliases decouple the code from the directory structure.
+ */
+function noRelativePaths(): OxlintRestrictedImportPattern {
+	return {
+		// language=regexp
+		regex: String.raw`^[/.]`,
+		message: "Prefer path aliases over relative paths.",
+	}
+}
+
+/**
+ * Using standardised APIs decouples the code from Node.js.
+ */
+function noNodeProtocol(): OxlintRestrictedImportPattern {
+	return {
+		// language=regexp
+		regex: String.raw`^node:.+`,
+		message: "Prefer the standard JavaScript library over Node.js specific modules.",
+	}
+}
+
+function noConfigs(): OxlintRestrictedImportPattern {
+	return {
+		// language=regexp
+		regex: String.raw`\.config\.[jt]s$`,
+		message: "Do not import configuration files.",
+	}
+}
+
+function noDecorators(): OxlintRestrictedImportPattern {
+	return {
+		// language=regexp
+		regex: String.raw`\.decorators\.[jt]sr?x?$`,
+		message: "Do not import story decorators.",
+	}
+}
+
+function noFixtures(): OxlintRestrictedImportPattern {
+	return {
+		// language=regexp
+		regex: String.raw`\.fixtures\.[jt]sr?x?$`,
+		message: "Do not import test fixtures.",
+	}
+}
+
+function noMocks(): OxlintRestrictedImportPattern {
+	return {
+		// language=regexp
+		regex: String.raw`\.mocks\.[jt]sr?x?$`,
+		message: "Do not import module mocks.",
+	}
+}
+
+function noScripts(): OxlintRestrictedImportPattern {
+	return {
+		// language=regexp
+		regex: String.raw`\.script\.[jt]s$`,
+		message: "Do not import Node.js scripts.",
+	}
+}
+
+function noStories(): OxlintRestrictedImportPattern {
+	return {
+		// language=regexp
+		regex: String.raw`\.stories\.[jt]sr?x?$`,
+		message: "Do not import stories.",
+	}
+}
+
+function noTests(): OxlintRestrictedImportPattern {
+	return {
+		// language=regexp
+		regex: String.raw`\.tests\.[jt]sr?x?$`,
+		message: "Do not import unit tests.",
+	}
 }

--- a/src/oxlint/OxlintStorybookPreset.ts
+++ b/src/oxlint/OxlintStorybookPreset.ts
@@ -1,4 +1,4 @@
-import type { OxlintConfig } from "oxlint"
+import type { OxlintConfig, OxlintOverride } from "oxlint"
 import { oxlintRestrictedImportPatterns } from "#oxlint/OxlintRestrictedImportPattern.ts"
 
 /**
@@ -7,73 +7,82 @@ import { oxlintRestrictedImportPatterns } from "#oxlint/OxlintRestrictedImportPa
  */
 export function oxlintStorybookPreset(): OxlintConfig {
 	return {
-		overrides: [
-			{
-				// Story decorators.
-				files: ["src/**/*.decorators.{ts,tsx}"],
-				rules: {
-					"eslint/complexity": ["warn", { max: 12, variant: "modified" }],
-					"eslint/no-restricted-imports": [
-						"warn",
-						{
-							patterns: oxlintRestrictedImportPatterns({
-								allowDecorators: true,
-								allowFixtures: true,
-							}),
-						},
-					],
+		overrides: [overrideDecorators(), overrideStories(), overrideStorybookConfig()],
+	}
+}
+
+function overrideDecorators(): OxlintOverride {
+	return {
+		files: ["src/**/*.decorators.{ts,tsx}"],
+		rules: {
+			"eslint/complexity": ["warn", { max: 12, variant: "modified" }],
+			"eslint/no-restricted-imports": [
+				"warn",
+				{
+					patterns: oxlintRestrictedImportPatterns({
+						allowDecorators: true,
+						allowFixtures: true,
+					}),
 				},
-			},
-			{
-				// CSF stories.
-				// https://storybook.js.org/docs/api/csf
-				files: ["src/**/*.stories.{ts,tsx}"],
-				rules: {
-					"eslint/complexity": ["warn", { max: 12, variant: "modified" }],
-					"eslint/no-restricted-exports": "off", // Allow default exports of static metadata.
-					"eslint/no-restricted-imports": [
-						"warn",
-						{
-							patterns: oxlintRestrictedImportPatterns({
-								allowMocks: true,
-								allowDecorators: true,
-								allowStories: true,
-								allowFixtures: true,
-							}),
-						},
-					],
-					"eslint/no-unused-vars": ["warn", { reportUsedIgnorePattern: false }],
-					"react/rules-of-hooks": "off", // Allow hooks in `render` components.
+			],
+		},
+	}
+}
+
+/**
+ * @see https://storybook.js.org/docs/api/csf
+ */
+function overrideStories(): OxlintOverride {
+	return {
+		files: ["src/**/*.stories.{ts,tsx}"],
+		rules: {
+			"eslint/complexity": ["warn", { max: 12, variant: "modified" }],
+			"eslint/no-restricted-exports": "off", // Allow default exports of static metadata.
+			"eslint/no-restricted-imports": [
+				"warn",
+				{
+					patterns: oxlintRestrictedImportPatterns({
+						allowMocks: true,
+						allowDecorators: true,
+						allowStories: true,
+						allowFixtures: true,
+					}),
 				},
-			},
-			{
-				// Storybook configuration files.
-				// https://storybook.js.org/docs/configure
-				files: [
-					".storybook/main.{ts,tsx}",
-					".storybook/manager.{ts,tsx}",
-					".storybook/preview.{ts,tsx}",
-				],
-				rules: {
-					"eslint/no-console": "off",
-					"eslint/no-restricted-exports": "off", // Allow default exports.
-					"eslint/no-restricted-globals": "off", // Allow access to environment variables through `process.env`.
-					"eslint/no-restricted-imports": [
-						"warn",
-						{
-							patterns: oxlintRestrictedImportPatterns({
-								allowRelativePaths: true,
-								allowNodejs: true,
-								allowFixtures: true,
-								allowDecorators: true,
-								allowMocks: true,
-							}),
-						},
-					],
-					"unicorn/filename-case": ["warn", { case: "kebabCase" }],
-					"unicorn/no-process-exit": "off",
-				},
-			},
+			],
+			"eslint/no-unused-vars": ["warn", { reportUsedIgnorePattern: false }],
+			"react/rules-of-hooks": "off", // Allow hooks in `render` components.
+		},
+	}
+}
+
+/**
+ * @see https://storybook.js.org/docs/configure
+ */
+function overrideStorybookConfig(): OxlintOverride {
+	return {
+		files: [
+			".storybook/main.{ts,tsx}",
+			".storybook/manager.{ts,tsx}",
+			".storybook/preview.{ts,tsx}",
 		],
+		rules: {
+			"eslint/no-console": "off",
+			"eslint/no-restricted-exports": "off", // Allow default exports.
+			"eslint/no-restricted-globals": "off", // Allow access to environment variables through `process.env`.
+			"eslint/no-restricted-imports": [
+				"warn",
+				{
+					patterns: oxlintRestrictedImportPatterns({
+						allowRelativePaths: true,
+						allowNodejs: true,
+						allowFixtures: true,
+						allowDecorators: true,
+						allowMocks: true,
+					}),
+				},
+			],
+			"unicorn/filename-case": ["warn", { case: "kebabCase" }],
+			"unicorn/no-process-exit": "off",
+		},
 	}
 }


### PR DESCRIPTION
This makes it easier in IntelliJ IDEA to ensure that rulesets are sorted
alphabetically.