### PR TITLE
Fix staged publishing to npm

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -76,5 +76,5 @@ jobs:
         run: |
           VERSION="$(jq -r '.version' ./package.json)"
           TAG="$([[ "$VERSION" == *[-+]* ]] && echo 'next' || echo 'latest')"
-          pnpm stage publish --provenance --access 'public' --tag "$TAG" --no-git-checks
+          vp pm stage publish --provenance --access 'public' --tag "$TAG" --no-git-checks
         shell: bash


### PR DESCRIPTION
The pnpm CLI is only available through Vite+ in the GitHub Actions workflow, as we don't install it explicitly with Corepack.

https://viteplus.dev/guide/install#staged-publishing